### PR TITLE
Add run_lwt and handle cancellation

### DIFF
--- a/lib/lwt_eio.ml
+++ b/lib/lwt_eio.ml
@@ -145,3 +145,6 @@ let run_eio fn =
       | exception ex -> Lwt.wakeup_exn r ex; notify ()
     );
   p
+
+let run_lwt fn =
+  Promise.await_lwt (fn ())

--- a/lib/lwt_eio.ml
+++ b/lib/lwt_eio.ml
@@ -138,13 +138,25 @@ end
 
 let run_eio fn =
   let sw = get_loop_switch () in
-  let p, r = Lwt.wait () in
+  let p, r = Lwt.task () in
+  let cc = ref None in
   Fiber.fork ~sw (fun () ->
-      match fn () with
-      | x -> Lwt.wakeup r x; notify ()
-      | exception ex -> Lwt.wakeup_exn r ex; notify ()
+      Eio.Cancel.sub (fun cancel ->
+          cc := Some cancel;
+          match fn () with
+          | x -> Lwt.wakeup r x; notify ()
+          | exception ex -> Lwt.wakeup_exn r ex; notify ()
+        )
     );
+  Lwt.on_cancel p (fun () -> Option.iter (fun cc -> Eio.Cancel.cancel cc Lwt.Canceled) !cc);
   p
 
 let run_lwt fn =
-  Promise.await_lwt (fn ())
+  Fiber.check ();
+  let p = fn () in
+  try
+    Fiber.check ();
+    Promise.await_lwt p
+  with Eio.Cancel.Cancelled _ as ex ->
+    Lwt.cancel p;
+    raise ex

--- a/lib/lwt_eio.mli
+++ b/lib/lwt_eio.mli
@@ -35,6 +35,11 @@ val run_eio : (unit -> 'a) -> 'a Lwt.t
     The new fiber is attached to the Lwt event loop's switch and will be
     cancelled if the function passed to {!with_event_loop} returns. *)
 
+val run_lwt : (unit -> 'a Lwt.t) -> 'a
+(** [run_lwt fn] allows running Lwt code from within an Eio function.
+    It runs [fn ()] to create a Lwt promise and then awaits it.
+    As running Lwt code from an Eio context is safe, this is just a wrapper around {!Promise.await_lwt}. *)
+
 val notify : unit -> unit
 (** [notify ()] causes [Lwt_engine.iter] to return,
     indicating that the event loop should run the hooks and resume yielded threads.

--- a/lib/lwt_eio.mli
+++ b/lib/lwt_eio.mli
@@ -32,13 +32,14 @@ end
 val run_eio : (unit -> 'a) -> 'a Lwt.t 
 (** [run_eio fn] allows running Eio code from within a Lwt function.
     It runs [fn ()] in a new Eio fiber and returns a promise for the result.
-    The new fiber is attached to the Lwt event loop's switch and will be
+    If the returned promise is cancelled, it will cancel the Eio fiber.
+    The new fiber is attached to the Lwt event loop's switch and will also be
     cancelled if the function passed to {!with_event_loop} returns. *)
 
 val run_lwt : (unit -> 'a Lwt.t) -> 'a
 (** [run_lwt fn] allows running Lwt code from within an Eio function.
     It runs [fn ()] to create a Lwt promise and then awaits it.
-    As running Lwt code from an Eio context is safe, this is just a wrapper around {!Promise.await_lwt}. *)
+    If the Eio fiber is cancelled, the Lwt promise is cancelled too. *)
 
 val notify : unit -> unit
 (** [notify ()] causes [Lwt_engine.iter] to return,


### PR DESCRIPTION
- `run_lwt` waits for an Lwt promise, and also cancels it if the Eio fiber is cancelled.
- `run_eio` cancels the Eio fiber if the Lwt promise is cancelled.
