### PR TITLE
Restore the old Lwt engine after finishing

### DIFF
--- a/test/test.md
+++ b/test/test.md
@@ -168,3 +168,14 @@ Trying to run Lwt code from an already-cancelled context fails immediately:
   );;
 Exception: Failure "Simulated error".
 ```
+
+## Cleanup
+
+After finishing with our mainloop, the old Lwt engine is ready for use again:
+
+```ocaml
+# run ignore;;
+- : unit = ()
+# Lwt_main.run (Lwt_unix.sleep 0.01);;
+- : unit = ()
+```


### PR DESCRIPTION
Note: using `~destroy:false` here is essential! Otherwise Lwt segfaults.

Reported by @tmcgilchrist - does this fix it for you?