### PR TITLE
Add Lwt_eio.run_lwt_in_main

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -1,4 +1,4 @@
 (library
   (name lwt_eio)
   (public_name lwt_eio)
-  (libraries eio.unix lwt.unix))
+  (libraries eio.unix eio.utils lwt.unix))


### PR DESCRIPTION
This is similar to `Lwt_preemptive.run_in_main`, but allows other Eio fibers to run while it's waiting.