### PR TITLE
Clarify use of `await_lwt`

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,17 +1,18 @@
 There are two example programs:
 
-- `simple.ml` runs a Lwt thread and an Eio fiber, communicating over a pair of streams.
+- `stream.ml` runs a Lwt thread and an Eio fiber, communicating over a pair of streams.
 - `chat.ml` runs a chat server.
   An Eio fiber accepts (loopback) connections on port 8001, while a Lwt thread accepts connections on port 8002.
   All clients on either port see the room history, which consists of all messages sent by any client as well as join/leave events.
 
 ```
-$ dune exec -- ./simple.exe
+$ dune exec -- ./stream.exe
 +Eio fiber waiting...
 Lwt thread sleeping...
 Lwt thread sending 1 to Eio
 +Eio fiber got "1" from Lwt
 +Eio fiber sleeping...
+Lwt thread waiting for response...
 +Eio fiber sending 2 to Lwt...
 +Eio fiber done
 Lwt got "2" from Eio

--- a/examples/dune
+++ b/examples/dune
@@ -1,3 +1,3 @@
 (executables
-  (names simple chat)
+  (names stream chat)
   (libraries eio_main lwt_eio logs.fmt))

--- a/examples/stream.ml
+++ b/examples/stream.ml
@@ -18,6 +18,8 @@ let main_lwt ~to_eio ~from_eio =
   let* () = Lwt_io.eprintf "Lwt thread sending 1 to Eio\n" in
   let* () = Lwt_io.(flush stderr) in
   let* () = to_eio "1" in
+  let* () = Lwt_io.eprintf "Lwt thread waiting for response...\n" in
+  let* () = Lwt_io.(flush stderr) in
   let* msg = from_eio () in
   let* () = Lwt_io.eprintf "Lwt got %S from Eio\n" msg in
   let* () = Lwt_io.(flush stderr) in
@@ -27,20 +29,11 @@ let () =
   (* Eio_unix.Ctf.with_tracing "/tmp/trace.ctf" @@ fun () -> *)
   Eio_main.run @@ fun env ->
   let clock = Eio.Stdenv.clock env in
-  Lwt_eio.with_event_loop ~clock @@ fun () ->
-  Switch.run @@ fun sw ->
-  let lwt_to_eio = Eio.Stream.create 1 in
-  let eio_to_lwt = Eio.Stream.create 1 in
-  let to_eio x =
-    let p, r = Lwt.wait () in
-    Fiber.fork ~sw (fun () -> Eio.Stream.add lwt_to_eio x; Lwt.wakeup r ());
-    p
-  in
-  let from_eio () =
-    let p, r = Lwt.wait () in
-    Fiber.fork ~sw (fun () -> Eio.Stream.take eio_to_lwt |> Lwt.wakeup r; Lwt_eio.notify ());
-    p
-  in
+  Lwt_eio.with_event_loop ~debug:true ~clock @@ fun () ->
+  let lwt_to_eio = Eio.Stream.create 0 in
+  let eio_to_lwt = Eio.Stream.create 0 in
+  let to_eio x = Lwt_eio.run_eio (fun () -> Eio.Stream.add lwt_to_eio x) in
+  let from_eio () = Lwt_eio.run_eio (fun () -> Eio.Stream.take eio_to_lwt) in
   Fiber.both
-    (fun () -> Lwt_eio.Promise.await_lwt (main_lwt ~to_eio ~from_eio))
+    (fun () -> Lwt_eio.run_lwt (fun () -> main_lwt ~to_eio ~from_eio))
     (fun () -> main ~clock ~from_lwt:lwt_to_eio ~to_lwt:eio_to_lwt)

--- a/lib/lwt_eio.mli
+++ b/lib/lwt_eio.mli
@@ -23,7 +23,11 @@ module Promise : sig
   val await_lwt : 'a Lwt.t -> 'a
   (** [await_lwt p] allows an Eio fiber to wait for a Lwt promise [p] to be resolved,
       much like {!Eio.Promise.await} does for Eio promises.
-      This can only be used while the event loop created by {!with_event_loop} is still running. *)
+
+      This can only be used while the event loop created by {!with_event_loop} is still running.
+
+      Note: in the usual case of needing to run some Lwt code to generate the promise first, use {!run_lwt} instead.
+      That handles cancellation and also tracks the current context so that debug mode works. *)
 
   val await_eio : 'a Eio.Promise.t -> 'a Lwt.t
   (** [await_eio p] allows a Lwt thread to wait for an Eio promise [p] to be resolved.


### PR DESCRIPTION
- Add note to `await_lwt`'s comment saying when to use `run_lwt` instead.

- Make examples work in debug mode. These were written before we had `run_eio` and `run_lwt`.

- Rename "simple" to "stream"; it's not particularly simple!

Should help with #29, reported by @patricoferris.